### PR TITLE
#12 - Only do setImageBitmap if new bitmap is different than the old one

### DIFF
--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java
@@ -220,6 +220,9 @@ public class CropImageView extends FrameLayout {
      * @param bitmap the Bitmap to set
      */
     public void setImageBitmap(Bitmap bitmap) {
+        if(mBitmap == bitmap) {
+            return;
+        }
 
         // if we allocated the bitmap, release it as fast as possible
         if (mBitmap != null && (mImageResource > 0 || mLoadedImageUri != null)) {


### PR DESCRIPTION
`Bitmap.createBitmap` says it could return the source image. This is happening during state restoration in   the `rotateImage` method.

The most defensive changed looks to be only do the setImageBitmap work if the new Bitmap isn't the same as the current Bitmap.

