### PR TITLE
Add better touch handling for oval crop shape

### DIFF
--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java
@@ -101,7 +101,7 @@ public class CropImageView extends FrameLayout {
     /**
      * The shape of the cropping area - rectangle/circular.
      */
-    private CropImageView.CropShape mCropShape;
+    private CropShape mCropShape;
 
     /**
      * The URI that the image was loaded from (if loaded from URI)
@@ -157,14 +157,14 @@ public class CropImageView extends FrameLayout {
     /**
      * The shape of the cropping area - rectangle/circular.
      */
-    public CropImageView.CropShape getCropShape() {
+    public CropShape getCropShape() {
         return mCropShape;
     }
 
     /**
      * The shape of the cropping area - rectangle/circular.
      */
-    public void setCropShape(CropImageView.CropShape cropShape) {
+    public void setCropShape(CropShape cropShape) {
         if (cropShape != mCropShape) {
             mCropShape = cropShape;
             mCropOverlayView.setCropShape(cropShape);
@@ -640,14 +640,4 @@ public class CropImageView extends FrameLayout {
     }
     //endregion
 
-    //region: Inner class: CropShape
-
-    /**
-     * The possible cropping area shape
-     */
-    public static enum CropShape {
-        RECTANGLE,
-        OVAL
-    }
-    //endregion
 }

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropShape.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropShape.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2013, Edmodo, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with the License.
+ * You may obtain a copy of the License in the LICENSE file, or at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.theartofdev.edmodo.cropper;
+
+/**
+ * The possible cropping area shape.
+ */
+public enum CropShape {
+    RECTANGLE,
+    OVAL
+}

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/cropwindow/CropOverlayView.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/cropwindow/CropOverlayView.java
@@ -28,6 +28,7 @@ import android.view.MotionEvent;
 import android.view.View;
 
 import com.theartofdev.edmodo.cropper.CropImageView;
+import com.theartofdev.edmodo.cropper.CropShape;
 import com.theartofdev.edmodo.cropper.cropwindow.edge.Edge;
 import com.theartofdev.edmodo.cropper.cropwindow.handle.Handle;
 import com.theartofdev.edmodo.cropper.util.AspectRatioUtil;
@@ -128,7 +129,7 @@ public class CropOverlayView extends View {
     /**
      * The shape of the cropping area - rectangle/circular.
      */
-    private CropImageView.CropShape mCropShape;
+    private CropShape mCropShape;
 
     // Whether the Crop View has been initialized for the first time
     private boolean initializedCropWindow = false;
@@ -176,7 +177,7 @@ public class CropOverlayView extends View {
     /**
      * The shape of the cropping area - rectangle/circular.
      */
-    public void setCropShape(CropImageView.CropShape cropShape) {
+    public void setCropShape(CropShape cropShape) {
         mCropShape = cropShape;
         invalidate();
     }
@@ -327,7 +328,7 @@ public class CropOverlayView extends View {
         float t = Edge.TOP.getCoordinate() + w;
         float r = Edge.RIGHT.getCoordinate() - w;
         float b = Edge.BOTTOM.getCoordinate() - w;
-        if (mCropShape == CropImageView.CropShape.RECTANGLE) {
+        if (mCropShape == CropShape.RECTANGLE) {
             // Draw rectangle crop window border.
             canvas.drawRect(l, t, r, b, mBorderPaint);
             drawCorners(canvas);
@@ -510,7 +511,7 @@ public class CropOverlayView extends View {
         float r = Edge.RIGHT.getCoordinate() - w;
         float b = Edge.BOTTOM.getCoordinate() - w;
 
-        if (mCropShape == CropImageView.CropShape.OVAL) {
+        if (mCropShape == CropShape.OVAL) {
             l += 15 * mGuidelinePaint.getStrokeWidth();
             t += 15 * mGuidelinePaint.getStrokeWidth();
             r -= 15 * mGuidelinePaint.getStrokeWidth();
@@ -541,7 +542,7 @@ public class CropOverlayView extends View {
         final float r = Edge.RIGHT.getCoordinate();
         final float b = Edge.BOTTOM.getCoordinate();
 
-        if (mCropShape == CropImageView.CropShape.RECTANGLE) {
+        if (mCropShape == CropShape.RECTANGLE) {
             canvas.drawRect(bitmapRect.left, bitmapRect.top, bitmapRect.right, t, mBackgroundPaint);
             canvas.drawRect(bitmapRect.left, b, bitmapRect.right, bitmapRect.bottom, mBackgroundPaint);
             canvas.drawRect(bitmapRect.left, t, l, b, mBackgroundPaint);
@@ -594,7 +595,7 @@ public class CropOverlayView extends View {
         final float right = Edge.RIGHT.getCoordinate();
         final float bottom = Edge.BOTTOM.getCoordinate();
 
-        mPressedHandle = HandleUtil.getPressedHandle(x, y, left, top, right, bottom, mHandleRadius);
+        mPressedHandle = HandleUtil.getPressedHandle(x, y, left, top, right, bottom, mHandleRadius, mCropShape);
 
         if (mPressedHandle == null) {
             return;

--- a/sample/src/main/java/com/theartofdev/edmodo/cropper/sample/MainActivity.java
+++ b/sample/src/main/java/com/theartofdev/edmodo/cropper/sample/MainActivity.java
@@ -26,6 +26,7 @@ import android.widget.ToggleButton;
 
 import com.example.croppersample.R;
 import com.theartofdev.edmodo.cropper.CropImageView;
+import com.theartofdev.edmodo.cropper.CropShape;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -118,7 +119,7 @@ public class MainActivity extends Activity {
 
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                cropImageView.setCropShape(isChecked ? CropImageView.CropShape.OVAL : CropImageView.CropShape.RECTANGLE);
+                cropImageView.setCropShape(isChecked ? CropShape.OVAL : CropShape.RECTANGLE);
             }
         });
 


### PR DESCRIPTION
The touch boundaries, especially when working with a larger image, are not in the ideal position for the corners when using the oval CropShape. The same bounding box is used for both crop shapes. This can lead to a confusing/bad user experience. See https://github.com/ArthurHub/Android-Image-Cropper/issues/15.

- Add method(s) to the HandleUtil that also take into account the CropShape.
- Refactor CropShape out of the CropImageView due to it being used in several classes.