### PR TITLE
Issue#17: Bug fix for Oval crop tool

### DIFF
--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/cropwindow/CropOverlayView.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/cropwindow/CropOverlayView.java
@@ -551,6 +551,7 @@ public class CropOverlayView extends View {
             Path circleSelectionPath = new Path();
             mRectF.set(l, t, r, b);
             circleSelectionPath.addOval(mRectF, Path.Direction.CW);
+            canvas.save();
             canvas.clipPath(circleSelectionPath, Region.Op.XOR);
             canvas.drawRect(bitmapRect.left, bitmapRect.top, bitmapRect.right, bitmapRect.bottom, mBackgroundPaint);
             canvas.restore();


### PR DESCRIPTION
**Changes:**
*  Bug fix for Oval crop tool.
* `canvas.restore()` wasn't balanced with `canvas.save()` in `drawBackground()` of `CropOverlayView` causing an IllegalStateException.