### PR TITLE
Fixed issue with getActualCropRect() while using setImageUriAsync(Uri)

### DIFF
--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/BitmapLoadingWorkerTask.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/BitmapLoadingWorkerTask.java
@@ -100,7 +100,7 @@ final class BitmapLoadingWorkerTask extends AsyncTask<Void, Void, BitmapLoadingW
                             : BitmapUtils.rotateBitmapByExif(mContext, decodeResult.bitmap, mUri);
 
                     Pair<Integer, Integer> sourceImageDimens = BitmapUtils.getImageDimensions(mContext, mUri);
-                    if(mPresetRotation == null) {
+                    if(mPreSetRotation == null) {
                         // In this case, rotateResult.degrees is due to Exif data.
                         if(rotateResult.degrees == 90 || rotateResult.degrees == 270)
                             sourceImageDimens = new Pair(sourceImageDimens.second, sourceImageDimens.first);

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/BitmapLoadingWorkerTask.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/BitmapLoadingWorkerTask.java
@@ -158,7 +158,7 @@ final class BitmapLoadingWorkerTask extends AsyncTask<Void, Void, BitmapLoadingW
         /**
          * The dimensions of source bitmap
          */
-        public final sourceImageDimensions;
+        public final Pair<Integer, Integer> sourceImageDimensions;
 
         /**
          * The sample size used to load the given bitmap
@@ -175,7 +175,7 @@ final class BitmapLoadingWorkerTask extends AsyncTask<Void, Void, BitmapLoadingW
          */
         public final Exception error;
 
-        Result(Uri uri, Bitmap bitmap, sourceImageDimens, int loadSampleSize, int degreesRotated) {
+        Result(Uri uri, Bitmap bitmap, Pair<Integer, Integer>, sourceImageDimens, int loadSampleSize, int degreesRotated) {
             this.uri = uri;
             this.bitmap = bitmap;
             this.sourceImageDimensions = sourceImageDimens;

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/BitmapLoadingWorkerTask.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/BitmapLoadingWorkerTask.java
@@ -175,7 +175,7 @@ final class BitmapLoadingWorkerTask extends AsyncTask<Void, Void, BitmapLoadingW
          */
         public final Exception error;
 
-        Result(Uri uri, Bitmap bitmap, Pair<Integer, Integer>, sourceImageDimens, int loadSampleSize, int degreesRotated) {
+        Result(Uri uri, Bitmap bitmap, Pair<Integer, Integer> sourceImageDimens, int loadSampleSize, int degreesRotated) {
             this.uri = uri;
             this.bitmap = bitmap;
             this.sourceImageDimensions = sourceImageDimens;

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/BitmapUtils.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/BitmapUtils.java
@@ -52,8 +52,6 @@ final class BitmapUtils {
         try {
             ContentResolver resolver = c.getContentResolver();
             stream = resolver.openInputStream(uri);
-
-            // First decode with inJustDecodeBounds=true to check dimensions
             BitmapFactory.Options options = new BitmapFactory.Options();
             options.inJustDecodeBounds = true;
             BitmapFactory.decodeStream(stream, new Rect(0, 0, 0, 0), options);

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/BitmapUtils.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/BitmapUtils.java
@@ -36,11 +36,34 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
+import android.util.Pair;
+
+
 /**
  * Utility class that deals with operations with an ImageView.
  */
 final class BitmapUtils {
 
+    /*
+    * Get dimensions of Bitmap from Uri
+    */
+    public static Pair<Integer, Integer> getImageDimensions(Context c, Uri uri) {
+        InputStream stream = null;
+        try {
+            ContentResolver resolver = c.getContentResolver();
+            stream = resolver.openInputStream(uri);
+
+            // First decode with inJustDecodeBounds=true to check dimensions
+            BitmapFactory.Options options = new BitmapFactory.Options();
+            options.inJustDecodeBounds = true;
+            BitmapFactory.decodeStream(stream, new Rect(0, 0, 0, 0), options);
+            closeSafe(stream);
+            return Pair.create(options.outWidth, options.outHeight);
+        } catch(Exception e) {
+            closeSafe(stream);
+            return null;
+        }
+    }
     /**
      * Gets the rectangular position of a Bitmap if it were placed inside a View.
      *

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java
@@ -719,7 +719,6 @@ public class CropImageView extends FrameLayout {
             clearImage(clearFull);
 
             mBitmap = bitmap;
-            mSourceImageDimensions = new Pair(bitmap.getWidth(), bitmap.getHeight());
             mImageView.setImageBitmap(mBitmap);
             if (mCropOverlayView != null) {
                 mCropOverlayView.resetCropOverlayView();

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java
@@ -377,7 +377,7 @@ public class CropImageView extends FrameLayout {
             actualCropLeft = Math.max(0f, actualCropLeft);
             actualCropTop = Math.max(0f, actualCropTop);
             actualCropRight = Math.min(mSourceImageDimensions.first, actualCropRight);
-            actualCropBottom = Math.min(mSourceBitmapDimensions.second, actualCropBottom);
+            actualCropBottom = Math.min(mSourceImageDimensions.second, actualCropBottom);
 
             return new Rect((int) actualCropLeft, (int) actualCropTop, (int) actualCropRight, (int) actualCropBottom);
         } else {

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java
@@ -972,7 +972,7 @@ public class CropImageView extends FrameLayout {
      * Get the scale factor between the actual Bitmap dimensions and the displayed dimensions.
      */
     private Pair<Float, Float> getScaleFactorWidth(Rect displayedImageRect) {
-        float actualImageWidth = mBitmap.getWidth
+        float actualImageWidth = mSourceImageDimensions.first;
         float displayedImageWidth = displayedImageRect.width();
         float scaleFactorWidth = actualImageWidth / displayedImageWidth;
 


### PR DESCRIPTION
getActualCropRect() works fine as long as we have loaded the source image as a bitmap, as mBitmap is the full sized image.

However, if we use setImageUri(Uri) or setImageUriAsync(), mBitmap is a scaled/sampled bitmap and using it in the actual crop rect calculation returns funny values.

This is my first proper PR anywhere. I hope it's acceptable.