### PR TITLE
Multi Touch Support for Crop Rectangle

### DIFF
--- a/cropper/build.gradle
+++ b/cropper/build.gradle
@@ -15,7 +15,7 @@ android {
     compileSdkVersion 23
     buildToolsVersion '23.0.1'
     defaultConfig {
-        minSdkVersion 10
+        minSdkVersion 11
         targetSdkVersion 23
         versionCode 1
         versionName PUBLISH_VERSION

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImage.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImage.java
@@ -514,6 +514,15 @@ public final class CropImage {
         }
 
         /**
+         * if multi touch functionality is enabled.<br>
+         * default: true.
+         */
+        public ActivityBuilder setMultiTouchEnabled(boolean multiTouchEnabled) {
+            mOptions.multiTouchEnabled = multiTouchEnabled;
+            return this;
+        }
+
+        /**
          * The max zoom allowed during cropping.<br>
          * <i>Default: 4</i>
          */

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageOptions.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageOptions.java
@@ -87,6 +87,12 @@ public class CropImageOptions implements Parcelable {
      */
     public boolean autoZoomEnabled;
 
+  /**
+   * if multi-touch should be enabled on the crop box
+   * default: false
+   */
+    public boolean multiTouchEnabled;
+
     /**
      * The max zoom allowed during cropping.
      */
@@ -267,6 +273,7 @@ public class CropImageOptions implements Parcelable {
         showCropOverlay = true;
         showProgressBar = true;
         autoZoomEnabled = true;
+        multiTouchEnabled = false;
         maxZoom = 4;
         initialCropWindowPaddingRatio = 0.1f;
 
@@ -321,6 +328,7 @@ public class CropImageOptions implements Parcelable {
         showCropOverlay = in.readByte() != 0;
         showProgressBar = in.readByte() != 0;
         autoZoomEnabled = in.readByte() != 0;
+        multiTouchEnabled = in.readByte() != 0;
         maxZoom = in.readInt();
         initialCropWindowPaddingRatio = in.readFloat();
         fixAspectRatio = in.readByte() != 0;
@@ -366,6 +374,7 @@ public class CropImageOptions implements Parcelable {
         dest.writeByte((byte) (showCropOverlay ? 1 : 0));
         dest.writeByte((byte) (showProgressBar ? 1 : 0));
         dest.writeByte((byte) (autoZoomEnabled ? 1 : 0));
+        dest.writeByte((byte) (multiTouchEnabled ? 1 : 0));
         dest.writeInt(maxZoom);
         dest.writeFloat(initialCropWindowPaddingRatio);
         dest.writeByte((byte) (fixAspectRatio ? 1 : 0));

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java
@@ -114,6 +114,12 @@ public class CropImageView extends FrameLayout {
     private boolean mAutoZoomEnabled = true;
 
     /**
+     * if multi touch functionality is enabled.<br>
+     * default: false.
+     */
+    private boolean mMultiTouchEnabled = false;
+
+    /**
      * The max zoom allowed during cropping
      */
     private int mMaxZoom;
@@ -199,6 +205,7 @@ public class CropImageView extends FrameLayout {
                     options.aspectRatioY = ta.getInteger(R.styleable.CropImageView_cropAspectRatioY, options.aspectRatioY);
                     options.scaleType = ScaleType.values()[ta.getInt(R.styleable.CropImageView_cropScaleType, options.scaleType.ordinal())];
                     options.autoZoomEnabled = ta.getBoolean(R.styleable.CropImageView_cropAutoZoomEnabled, options.autoZoomEnabled);
+                    options.multiTouchEnabled = ta.getBoolean(R.styleable.CropImageView_cropMultiTouchEnabled, options.multiTouchEnabled);
                     options.maxZoom = ta.getInteger(R.styleable.CropImageView_cropMaxZoom, options.maxZoom);
                     options.cropShape = CropShape.values()[ta.getInt(R.styleable.CropImageView_cropShape, options.cropShape.ordinal())];
                     options.guidelines = Guidelines.values()[ta.getInt(R.styleable.CropImageView_cropGuidelines, options.guidelines.ordinal())];
@@ -303,6 +310,17 @@ public class CropImageView extends FrameLayout {
     public void setAutoZoomEnabled(boolean autoZoomEnabled) {
         if (mAutoZoomEnabled != autoZoomEnabled) {
             mAutoZoomEnabled = autoZoomEnabled;
+            handleCropWindowChanged(false, false);
+            mCropOverlayView.invalidate();
+        }
+    }
+
+    /**
+     * Set multi touch functionality to enabled/disabled.
+     */
+    public void setMultiTouchEnabled(boolean multiTouchEnabled) {
+        if (mMultiTouchEnabled != multiTouchEnabled) {
+            mMultiTouchEnabled = multiTouchEnabled;
             handleCropWindowChanged(false, false);
             mCropOverlayView.invalidate();
         }

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropOverlayView.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropOverlayView.java
@@ -40,6 +40,11 @@ public class CropOverlayView extends View {
      */
     private ScaleGestureDetector mScaleDetector;
 
+  /**
+   * Boolean to see if multi touch is enabled for the crop rectangle
+   */
+  private boolean mMultiTouchEnabled;
+
     /**
      * Handler from crop window stuff, moving and knowing possition.
      */
@@ -443,6 +448,8 @@ public class CropOverlayView extends View {
 
         mTouchRadius = options.touchRadius;
 
+        mMultiTouchEnabled = options.multiTouchEnabled;
+
         mInitialCropWindowPaddingRatio = options.initialCropWindowPaddingRatio;
 
         mBorderPaint = getNewPaintOrNull(options.borderLineThickness, options.borderLineColor);
@@ -802,9 +809,11 @@ public class CropOverlayView extends View {
     @Override
     public boolean onTouchEvent(MotionEvent event) {
         // If this View is not enabled, don't allow for touch interactions.
-        mScaleDetector.onTouchEvent(event);
-
         if (isEnabled()) {
+            if (mMultiTouchEnabled) {
+                mScaleDetector.onTouchEvent(event);
+            }
+
             switch (event.getAction()) {
                 case MotionEvent.ACTION_DOWN:
                     onActionDown(event.getX(), event.getY());
@@ -986,6 +995,10 @@ public class CropOverlayView extends View {
     }
     //endregion
 
+    //region: Inner class: ScaleListener
+    /**
+     * Handle scaling the rectangle based on two finger input
+     */
     private class ScaleListener extends ScaleGestureDetector.SimpleOnScaleGestureListener {
         @Override
         public boolean onScale(ScaleGestureDetector detector) {
@@ -1016,5 +1029,5 @@ public class CropOverlayView extends View {
             return true;
         }
     }
-
+    //endregion
 }

--- a/cropper/src/main/res/values/attrs.xml
+++ b/cropper/src/main/res/values/attrs.xml
@@ -18,6 +18,7 @@
         </attr>
         <attr name="cropAutoZoomEnabled" format="boolean"/>
         <attr name="cropMaxZoom" format="integer"/>
+        <attr name="cropMultiTouchEnabled" format="boolean"/>
         <attr name="cropFixAspectRatio" format="boolean"/>
         <attr name="cropAspectRatioX" format="integer"/>
         <attr name="cropAspectRatioY" format="integer"/>

--- a/quick-start/src/main/java/com/theartofdev/edmodo/cropper/quick/start/MainActivity.java
+++ b/quick-start/src/main/java/com/theartofdev/edmodo/cropper/quick/start/MainActivity.java
@@ -95,6 +95,7 @@ public class MainActivity extends AppCompatActivity {
     private void startCropImageActivity(Uri imageUri) {
         CropImage.activity(imageUri)
                 .setGuidelines(CropImageView.Guidelines.ON)
+                .setMultiTouchEnabled(true)
                 .start(this);
     }
 }


### PR DESCRIPTION
Enable multi touch support on crop rectangle

This is configurable through the activity builder and is set to false by default, so it does not change current behavior.

Following convention in the plugin, one can turn this on or off through the multiTouchEnabled boolean.

There is one caveat, in order to use the getCurrentSpanX(Y) on the gesture detector, I needed to bump the minSdkVersion to 11.