### PR TITLE
image picker bugfix for xiaomi and huawei phones

### DIFF
--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImage.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImage.java
@@ -175,11 +175,10 @@ public final class CropImage {
         allIntents.addAll(galleryIntents);
 
         Intent target;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (allIntents.isEmpty()) {
             target = new Intent();
         } else {
-            target = allIntents.get(allIntents.size() - 1);
-            allIntents.remove(allIntents.size() - 1);
+            target = allIntents.remove(0);
         }
 
         // Create a chooser from the main  intent


### PR DESCRIPTION
Fixes empty image picker on huawei and xiaomi phone as in #132. Tested on Xiaomi MI5.