### PR TITLE
Start a picker to choose image if no image uri is provided

### DIFF
--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImage.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImage.java
@@ -50,6 +50,7 @@ import java.util.List;
  * Added value you get out-of-the-box is some edge case handling that you may miss otherwise, like the
  * stupid-ass Android camera result URI that may differ from version to version and from device to device.
  */
+@SuppressWarnings("WeakerAccess, unused")
 public final class CropImage {
 
     //region: Fields and Consts
@@ -379,6 +380,7 @@ public final class CropImage {
         /**
          * The image to crop source Android uri.
          */
+        @Nullable
         private final Uri mSource;
 
         /**
@@ -386,7 +388,7 @@ public final class CropImage {
          */
         private final CropImageOptions mOptions;
 
-        private ActivityBuilder(@NonNull Uri source) {
+        private ActivityBuilder(@Nullable Uri source) {
             mSource = source;
             mOptions = new CropImageOptions();
         }

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImage.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImage.java
@@ -164,8 +164,10 @@ public final class CropImage {
         List<Intent> allIntents = new ArrayList<>();
         PackageManager packageManager = context.getPackageManager();
 
-        // collect all camera intents
-        allIntents.addAll(getCameraIntents(context, packageManager));
+        // collect all camera intents if Camera permission is available
+        if (!isExplicitCameraPermissionRequired(context)) {
+            allIntents.addAll(getCameraIntents(context, packageManager));
+        }
 
         List<Intent> galleryIntents = getGalleryIntents(packageManager, Intent.ACTION_GET_CONTENT, includeDocuments);
         if (galleryIntents.size() == 0) {
@@ -350,13 +352,10 @@ public final class CropImage {
      * Result will be recieved in {@link Activity#onActivityResult(int, int, Intent)} and can be retrieved
      * using {@link #getActivityResult(Intent)}.
      *
-     * @param uri the image Android uri source to crop
+     * @param uri the image Android uri source to crop or null to start a picker
      * @return builder for Crop Image Activity
      */
-    public static ActivityBuilder activity(@NonNull Uri uri) {
-        if (uri == null || uri.equals(Uri.EMPTY)) {
-            throw new IllegalArgumentException("Uri must be non null or empty");
-        }
+    public static ActivityBuilder activity(@Nullable Uri uri) {
         return new ActivityBuilder(uri);
     }
 

--- a/quick-start/src/main/AndroidManifest.xml
+++ b/quick-start/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.CAMERA"/>
 
     <application
         android:allowBackup="false"

--- a/quick-start/src/main/java/com/theartofdev/edmodo/cropper/quick/start/MainActivity.java
+++ b/quick-start/src/main/java/com/theartofdev/edmodo/cropper/quick/start/MainActivity.java
@@ -12,11 +12,7 @@
 
 package com.theartofdev.edmodo.cropper.quick.start;
 
-import android.Manifest;
-import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -29,11 +25,6 @@ import com.theartofdev.edmodo.cropper.CropImageView;
 
 public class MainActivity extends AppCompatActivity {
 
-    /**
-     * Persist URI image to crop URI if specific permissions are required
-     */
-    private Uri mCropImageUri;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -44,27 +35,11 @@ public class MainActivity extends AppCompatActivity {
      * Start pick image activity with chooser.
      */
     public void onSelectImageClick(View view) {
-        CropImage.startPickImageActivity(this);
+        startCropImageActivity(null);
     }
 
     @Override
-    @SuppressLint("NewApi")
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-
-        // handle result of pick image chooser
-        if (requestCode == CropImage.PICK_IMAGE_CHOOSER_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
-            Uri imageUri = CropImage.getPickImageResultUri(this, data);
-
-            // For API >= 23 we need to check specifically that we have permissions to read external storage.
-            if (CropImage.isReadExternalStoragePermissionsRequired(this, imageUri)) {
-                // request permissions and handle the result in onRequestPermissionsResult()
-                mCropImageUri = imageUri;
-                requestPermissions(new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, 0);
-            } else {
-                // no permissions required or already grunted, can start crop image activity
-                startCropImageActivity(imageUri);
-            }
-        }
 
         // handle result of CropImageActivity
         if (requestCode == CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE) {
@@ -75,16 +50,6 @@ public class MainActivity extends AppCompatActivity {
             } else if (resultCode == CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE) {
                 Toast.makeText(this, "Cropping failed: " + result.getError(), Toast.LENGTH_LONG).show();
             }
-        }
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
-        if (mCropImageUri != null && grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-            // required permissions granted, start crop image activity
-            startCropImageActivity(mCropImageUri);
-        } else {
-            Toast.makeText(this, "Cancelling, required permissions are not granted", Toast.LENGTH_LONG).show();
         }
     }
 


### PR DESCRIPTION
There is no change in the way library is invoked, except that it now allows you to pass a null or empty Uri.

The changes in this PR are:

**CropImage**
- `CropImage.activity(Uri)` method does not throw exception if image uri is null or empty. We can also alternatively create a new method, but I thought this might be better to have a single entry point.
- If camera permission is not available when collect the intents to show the image pickers, the camera related intents are ignored. This allows us to create a picker without always needing the camera permission.
- Changes to annotations for allowing null uri and remove lint warnings.

**CropImageActivity**
- If the passed uri requires storage permission, request the permission and set image after receiving permission.
- If the passed uri is null, start a picker. However, if camera permission is explicitly required, request the camera permission first and then start the picker in the onRequestPermissionsResult.
- We dont care whether the user allowed or denied the camera permission. CropImage picker will automatically remove the camera intents if permission is not available.

**AndroidManifest of QuickStart Sample**
- Request Camera permission to test for permission handling. Not actually required for quickstart sample. Can be removed after testing.

**QuickStart MainActivity**
- Removed unnecessary code not required after the new change. 
