### PR TITLE
Fixes counter-clockwise rotation

### DIFF
--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java
@@ -860,14 +860,20 @@ public class CropImageView extends FrameLayout {
 
     /**
      * Rotates image by the specified number of degrees clockwise.<br>
-     * Cycles from 0 to 360 degrees.
+     * Negative values represent counter-clockwise rotations.
      *
      * @param degrees Integer specifying the number of degrees to rotate.
      */
     public void rotateImage(int degrees) {
         if (mBitmap != null) {
+            // Force degrees to be a non-zero value between 0 and 360 (inclusive)
+            if (degrees < 0) {
+                degrees = (degrees % 360) + 360;
+            } else {
+                degrees = degrees % 360;
+            }
 
-            boolean flipAxes = !mCropOverlayView.isFixAspectRatio() && (degrees > 45 && degrees < 135) || (degrees > 215 && degrees < 305);
+            boolean flipAxes = !mCropOverlayView.isFixAspectRatio() && ((degrees > 45 && degrees < 135) || (degrees > 215 && degrees < 305));
             BitmapUtils.RECT.set(mCropOverlayView.getCropWindowRect());
             float halfWidth = (flipAxes ? BitmapUtils.RECT.height() : BitmapUtils.RECT.width()) / 2f;
             float halfHeight = (flipAxes ? BitmapUtils.RECT.width() : BitmapUtils.RECT.height()) / 2f;
@@ -882,8 +888,8 @@ public class CropImageView extends FrameLayout {
             BitmapUtils.POINTS[5] = 0;
             mImageInverseMatrix.mapPoints(BitmapUtils.POINTS);
 
-            mDegreesRotated += degrees;
-            mDegreesRotated = mDegreesRotated >= 0 ? mDegreesRotated % 360 : mDegreesRotated % 360 + 360;
+            // This is valid because degrees is not negative.
+            mDegreesRotated = (mDegreesRotated + degrees) % 360;
 
             applyImageMatrix(getWidth(), getHeight(), true, false);
 


### PR DESCRIPTION
When you specify `CropImageOptions.allowCounterRotation = true`, the `crop_image_menu_rotate_left` `MenuItem` is shown. When it is selected, the code `rotateImage(-mOptions.rotationDegrees);` is executed. Yet the `rotateImage` method expected a value between 0 and 360. This creates unexpected behavior when one rotates an image counter-clockwise and the image's crop rectangle is not a square, or when `CropImageOptions.rotationDegrees` is set to an unusual value, such as 450 or -90.

I've fixed the `CropImageView.rotateImage(int)` method. At the beginning of the method, I ensure that the `degrees` parameter be in the range [0, 360]. Now, because `degrees` is always non-negative, I can simplify the computation that changes `mDegreesRotated`. Additionally, the computation for `flipAxes` was missing parentheses, so I fixed that as well.

It should be noted that the forcing of the degrees to a non-zero value in the range `[0,360)` can be simplified to just:

    degrees = ((degrees % 360) + 360) % 360;

I left the more verbose `if` statement to make it more obvious what the code was doing.

Collectively, these changes ensure that the image is correctly rotated, even if the value passed in is outside of the range [0, 360]. This is particularly important for counter-clockwise rotations.