### PR TITLE
Android Studio 3.0 - Fixed undefined drawable

### DIFF
--- a/cropper/src/main/res/values/ids.xml
+++ b/cropper/src/main/res/values/ids.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <item name="crop_image_menu_crop" type="drawable"/>
+    <item name="crop_image_menu_crop" type="drawable">@null</item>
 </resources>


### PR DESCRIPTION
With Gradle plugin 3.0-alpha2 and above, resource values have to be defined

This PR assigns `@null` default value to the `crop_image_menu_crop` drawable

## Steps to reproduce
 1. Install Android Studio 3.0 Canary 2, with Gradle plugin 3.0-alpha2
 2. Build with library
 3. Try to sync Gradle

## Log

```
:app:buildInfoGeneratorInviDevelopmentDebug (Thread[Task worker,5,main]) completed. Took 0.002 secs.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:mergeInviDevelopmentDebugResources'.
> Error: java.lang.RuntimeException: com.android.builder.internal.aapt.AaptException: AAPT2 compile failed:
  aapt2 compile --no-crunch -o /Users/Adrien/Work/invi/android/app/build/intermediates/res/merged/inviDevelopment/debug /Users/Adrien/Work/invi/android/app/build/intermediates/incremental/mergeInviDevelopmentDebugResources/merged.dir/values/values.xml
  Issues:
   - ERROR: /Users/Adrien/Work/invi/android/app/build/intermediates/incremental/mergeInviDevelopmentDebugResources/merged.dir/values/values.xml:1767 invalid drawable
```

## Temporary fix
Before this gets merged and shipped, you can still use the library by declaring in your app resources
```
    <item name="crop_image_menu_crop" type="drawable">@null</item>
```