### PR TITLE
Making the library JitPack-friendly.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
 }
 

--- a/cropper/build.gradle
+++ b/cropper/build.gradle
@@ -1,7 +1,10 @@
 apply plugin: 'com.android.library'
 // https://docs.gradle.org/current/userguide/publishing_maven.html
 // http://www.flexlabs.org/2013/06/using-local-aar-android-library-packages-in-gradle-builds
+apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'maven-publish'
+
+group='com.github.ArthurHub'
 
 ext {
     PUBLISH_GROUP_ID = 'com.theartofdev.edmodo'


### PR DESCRIPTION
This should make the library JitPack-friendly, so that others can fork and use it through JitPack easily. I currently had to make these changes in my fork to be able to use it through JitPack: https://github.com/gazialankus/Android-Image-Cropper 

This did require some head scratching: https://stackoverflow.com/questions/44841415/jitpack-wont-use-a-github-repo-included-sample-repo-that-demonstrates-the-iss 

Hopefully this PR will make it easier for others in the future. I think leaving the group variable as your github account will be fine for forks, since this does not mention it: https://5am.technology/2016/12/fix-bugs-third-party-dependency-jitpack/