### PR TITLE
Added original image dimensions to CropResult.

### DIFF
--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImage.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImage.java
@@ -908,8 +908,8 @@ public final class CropImage {
         };
 
         public ActivityResult(Uri originalUri, Uri uri, Exception error,
-                              float[] cropPoints, Rect cropRect, int rotation, int sampleSize) {
-            super(null, originalUri, null, uri, error, cropPoints, cropRect, rotation, sampleSize);
+                              float[] cropPoints, Rect cropRect, int rotation, Rect wholeImageRect, int sampleSize) {
+            super(null, originalUri, null, uri, error, cropPoints, cropRect, wholeImageRect, rotation, sampleSize);
         }
 
         protected ActivityResult(Parcel in) {
@@ -919,6 +919,7 @@ public final class CropImage {
                     (Uri) in.readParcelable(Uri.class.getClassLoader()),
                     (Exception) in.readSerializable(),
                     in.createFloatArray(),
+                    (Rect) in.readParcelable(Rect.class.getClassLoader()),
                     (Rect) in.readParcelable(Rect.class.getClassLoader()),
                     in.readInt(),
                     in.readInt());
@@ -931,6 +932,7 @@ public final class CropImage {
             dest.writeSerializable(getError());
             dest.writeFloatArray(getCropPoints());
             dest.writeParcelable(getCropRect(), flags);
+            dest.writeParcelable(getWholeImageRect(), flags);
             dest.writeInt(getRotation());
             dest.writeInt(getSampleSize());
         }

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageActivity.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageActivity.java
@@ -314,6 +314,7 @@ public class CropImageActivity extends AppCompatActivity implements CropImageVie
                 mCropImageView.getCropPoints(),
                 mCropImageView.getCropRect(),
                 mCropImageView.getRotatedDegrees(),
+                mCropImageView.getWholeImageRect(),
                 sampleSize);
         Intent intent = new Intent();
         intent.putExtra(CropImage.CROP_IMAGE_EXTRA_RESULT, result);

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java
@@ -614,6 +614,17 @@ public class CropImageView extends FrameLayout {
     }
 
     /**
+     * Gets the source Bitmap's dimensions. This represents the largest possible crop rectangle.
+     *
+     * @return a Rect instance dimensions of the source Bitmap
+     */
+    public Rect getWholeImageRect() {
+        int orgWidth = mBitmap.getWidth() * mLoadedSampleSize;
+        int orgHeight = mBitmap.getHeight() * mLoadedSampleSize;
+        return new Rect(0, 0, orgWidth, orgHeight);
+    }
+
+    /**
      * Gets the crop window's position relative to the source Bitmap (not the image
      * displayed in the CropImageView) using the original image rotation.
      *
@@ -1067,7 +1078,7 @@ public class CropImageView extends FrameLayout {
         OnCropImageCompleteListener listener = mOnCropImageCompleteListener;
         if (listener != null) {
             CropResult cropResult = new CropResult(mBitmap, mLoadedImageUri, result.bitmap, result.uri, result.error,
-                    getCropPoints(), getCropRect(), getRotatedDegrees(), result.sampleSize);
+                    getCropPoints(), getCropRect(), getWholeImageRect(), getRotatedDegrees(), result.sampleSize);
             listener.onCropImageComplete(this, cropResult);
         }
     }
@@ -1806,6 +1817,11 @@ public class CropImageView extends FrameLayout {
         private final Rect mCropRect;
 
         /**
+         * The rectangle of the source image dimensions
+         */
+        private final Rect mWholeImageRect;
+
+        /**
          * The final rotation of the cropped image relative to source
          */
         private final int mRotation;
@@ -1816,7 +1832,7 @@ public class CropImageView extends FrameLayout {
         private final int mSampleSize;
 
         CropResult(Bitmap originalBitmap, Uri originalUri, Bitmap bitmap, Uri uri, Exception error,
-                   float[] cropPoints, Rect cropRect, int rotation, int sampleSize) {
+                   float[] cropPoints, Rect cropRect, Rect wholeImageRect, int rotation, int sampleSize) {
             mOriginalBitmap = originalBitmap;
             mOriginalUri = originalUri;
             mBitmap = bitmap;
@@ -1824,6 +1840,7 @@ public class CropImageView extends FrameLayout {
             mError = error;
             mCropPoints = cropPoints;
             mCropRect = cropRect;
+            mWholeImageRect = wholeImageRect;
             mRotation = rotation;
             mSampleSize = sampleSize;
         }
@@ -1886,6 +1903,13 @@ public class CropImageView extends FrameLayout {
          */
         public Rect getCropRect() {
             return mCropRect;
+        }
+
+        /**
+         * The rectangle of the source image dimensions
+         */
+        public Rect getWholeImageRect() {
+            return mWholeImageRect;
         }
 
         /**


### PR DESCRIPTION
With this PR, we should be able to get the whole image dimensions in a rect in CropResult. I had an issue about this before here: https://github.com/ArthurHub/Android-Image-Cropper/issues/324

I tested this code in my master branch over here with JitPack: https://github.com/gazialankus/Android-Image-Cropper/tree/master and then I cherry picked from there to create this PR. The code is the same, so it should just work. 