### PR TITLE
fix NPE in getWholeImageRect(). resolve #339

### DIFF
--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java
@@ -622,6 +622,10 @@ public class CropImageView extends FrameLayout {
      * @return a Rect instance dimensions of the source Bitmap
      */
     public Rect getWholeImageRect() {
+        if (mBitmap == null) {
+            return null;
+        }
+        
         int orgWidth = mBitmap.getWidth() * mLoadedSampleSize;
         int orgHeight = mBitmap.getHeight() * mLoadedSampleSize;
         return new Rect(0, 0, orgWidth, orgHeight);


### PR DESCRIPTION
we have check in getCropRect(), but haven't in getWholeImageRect(). 
it causes many NPE in the prod