### PR TITLE
Fix crash when options from Intent are null

### DIFF
--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageActivity.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageActivity.java
@@ -86,7 +86,7 @@ public class CropImageActivity extends AppCompatActivity
 
     ActionBar actionBar = getSupportActionBar();
     if (actionBar != null) {
-      CharSequence title =
+      CharSequence title = mOptions != null &&
           mOptions.activityTitle != null && mOptions.activityTitle.length() > 0
               ? mOptions.activityTitle
               : getResources().getString(R.string.crop_image_activity_title);


### PR DESCRIPTION
Mentioned in https://github.com/ArthurHub/Android-Image-Cropper/issues/502

Probably caused by Android sandbox / security scanner starting Activities.