### PR TITLE
[FIX] Crash on Android O

### DIFF
--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropOverlayView.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropOverlayView.java
@@ -618,7 +618,11 @@ public class CropOverlayView extends View {
         mPath.close();
 
         canvas.save();
-        canvas.clipPath(mPath, Region.Op.INTERSECT);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+          canvas.clipOutPath(mPath);
+        } else {
+          canvas.clipPath(mPath, Region.Op.INTERSECT);
+        }
         canvas.clipRect(rect, Region.Op.XOR);
         canvas.drawRect(left, top, right, bottom, mBackgroundPaint);
         canvas.restore();
@@ -632,7 +636,11 @@ public class CropOverlayView extends View {
       }
       mPath.addOval(mDrawRect, Path.Direction.CW);
       canvas.save();
-      canvas.clipPath(mPath, Region.Op.XOR);
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        canvas.clipOutPath(mPath);
+      } else {
+        canvas.clipPath(mPath, Region.Op.INTERSECT);
+      }
       canvas.drawRect(left, top, right, bottom, mBackgroundPaint);
       canvas.restore();
     }


### PR DESCRIPTION
### Description

This library is crashing on  Android O with:
```
10-12 20:22:57.086 16220 16220 E AndroidRuntime: FATAL EXCEPTION: main
10-12 20:22:57.086 16220 16220 E AndroidRuntime: Process: com.n3twork.nwinternal, PID: 16220
10-12 20:22:57.086 16220 16220 E AndroidRuntime: java.lang.IllegalArgumentException: Invalid Region.Op - only INTERSECT and DIFFERENCE are allowed
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.graphics.Canvas.checkValidClipOp(Canvas.java:779)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.graphics.Canvas.clipPath(Canvas.java:1007)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at com.theartofdev.edmodo.cropper.CropOverlayView.a(CropOverlayView.java:635)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at com.theartofdev.edmodo.cropper.CropOverlayView.onDraw(CropOverlayView.java:579)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.View.draw(View.java:20207)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19082)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.View.draw(View.java:19935)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ViewGroup.drawChild(ViewGroup.java:4333)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4112)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19073)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.View.draw(View.java:19935)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ViewGroup.drawChild(ViewGroup.java:4333)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4112)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19073)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.View.draw(View.java:19935)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ViewGroup.drawChild(ViewGroup.java:4333)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4112)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19073)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.View.draw(View.java:19935)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ViewGroup.drawChild(ViewGroup.java:4333)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4112)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19073)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.View.draw(View.java:19935)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ViewGroup.drawChild(ViewGroup.java:4333)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4112)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19073)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.View.draw(View.java:19935)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ViewGroup.drawChild(ViewGroup.java:4333)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4112)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.View.draw(View.java:20210)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at com.android.internal.policy.DecorView.draw(DecorView.java:780)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.View.updateDisplayListIfDirty(View.java:19082)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ThreadedRenderer.updateViewTreeDisplayList(ThreadedRenderer.java:686)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ThreadedRenderer.updateRootDisplayList(ThreadedRenderer.java:692)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ThreadedRenderer.draw(ThreadedRenderer.java:801)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ViewRootImpl.draw(ViewRootImpl.java:3312)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ViewRootImpl.performDraw(ViewRootImpl.java:3116)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2485)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1460)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:7184)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:949)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.Choreographer.doCallbacks(Choreographer.java:761)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.Choreographer.doFrame(Choreographer.java:696)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:935)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:873)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:99)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:193)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:6669)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
10-12 20:22:57.086 16220 16220 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
```

### Solution

Stop using [this deprecated method](https://developer.android.com/reference/android/graphics/Canvas#clipPath(android.graphics.Path,%20android.graphics.Region.Op)) if we are on Android O or superior.