### PR TITLE
Removing need to add Activity to App Manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,7 @@ Add this line to your Proguard config file
 ```
 ### Using Activity
 
-2. Add `CropImageActivity` into your AndroidManifest.xml
- ```xml
- <activity android:name="com.theartofdev.edmodo.cropper.CropImageActivity"
-   android:theme="@style/Base.Theme.AppCompat"/> <!-- optional (needed if default theme has no action bar) -->
- ```
-
-3. Start `CropImageActivity` using builder pattern from your activity
+2. Start `CropImageActivity` using builder pattern from your activity
  ```java
  // start picker to get image for cropping and then use the image in cropping activity
  CropImage.activity()
@@ -57,7 +51,7 @@ Add this line to your Proguard config file
    .start(getContext(), this);
  ```
 
-4. Override `onActivityResult` method in your activity to get crop result
+3. Override `onActivityResult` method in your activity to get crop result
  ```java
  @Override
  public void onActivityResult(int requestCode, int resultCode, Intent data) {

--- a/cropper/src/main/AndroidManifest.xml
+++ b/cropper/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
 <manifest
-    package="com.theartofdev.edmodo.cropper">
+    package="com.theartofdev.edmodo.cropper"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
        <application>
             <activity android:name="com.theartofdev.edmodo.cropper.CropImageActivity"

--- a/cropper/src/main/AndroidManifest.xml
+++ b/cropper/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <manifest
     package="com.theartofdev.edmodo.cropper">
 
+       <application>
+            <activity android:name="com.theartofdev.edmodo.cropper.CropImageActivity"
+                android:theme="@style/Base.Theme.AppCompat"/>
+        </application>
 </manifest>

--- a/quick-start/src/main/AndroidManifest.xml
+++ b/quick-start/src/main/AndroidManifest.xml
@@ -20,6 +20,5 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
-        <activity android:name="com.theartofdev.edmodo.cropper.CropImageActivity"/>
     </application>
 </manifest>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -22,9 +22,6 @@
         </activity>
         <activity android:name="com.theartofdev.edmodo.cropper.sample.CropResultActivity">
         </activity>
-        <activity android:name="com.theartofdev.edmodo.cropper.CropImageActivity">
-        </activity>
-
     </application>
 
 </manifest>


### PR DESCRIPTION
Now there is no need for the users to add CropImageActivity to their Manifest. This is because you're using **Intent.setClass** method. I just added the activity to the library manifest