### PR TITLE
fix test module dependency to use the cropper android library module

### DIFF
--- a/test/build.gradle
+++ b/test/build.gradle
@@ -17,6 +17,6 @@ android {
 
 dependencies {
     api "androidx.appcompat:appcompat:$androidXLibraryVersion"
-    api 'com.theartofdev.edmodo:android-image-cropper:2.7.0'
+    implementation project(":cropper")
 
 }


### PR DESCRIPTION
It made more sense to me to actually test the current "cropper" android library module.