### PR TITLE
fix npe issue https://github.com/ArthurHub/Android-Image-Cropper/issues/551

### DIFF
--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageActivity.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageActivity.java
@@ -60,8 +60,13 @@ public class CropImageActivity extends AppCompatActivity
     mCropImageView = findViewById(R.id.cropImageView);
 
     Bundle bundle = getIntent().getBundleExtra(CropImage.CROP_IMAGE_EXTRA_BUNDLE);
-    mCropImageUri = bundle.getParcelable(CropImage.CROP_IMAGE_EXTRA_SOURCE);
-    mOptions = bundle.getParcelable(CropImage.CROP_IMAGE_EXTRA_OPTIONS);
+    if (bundle != null) {
+      mCropImageUri = bundle.getParcelable(CropImage.CROP_IMAGE_EXTRA_SOURCE);
+      mOptions = bundle.getParcelable(CropImage.CROP_IMAGE_EXTRA_OPTIONS);
+    } else {
+      Log.w(getClass().getSimpleName(), "No crop image extra bundle provided!");
+      finish();
+    }
 
     if (savedInstanceState == null) {
       if (mCropImageUri == null || mCropImageUri.equals(Uri.EMPTY)) {


### PR DESCRIPTION
see related issue https://github.com/ArthurHub/Android-Image-Cropper/issues/551

```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'android.os.Parcelable android.os.Bundle.getParcelable(java.lang.String)' on a null object reference
at com.theartofdev.edmodo.cropper.CropImageActivity.onCreate(CropImageActivity.java:63)
```

Fix by finishing the CropImageActivity gracefully (which gives the user the opportunity to try selecting an image again) instead of app crash.