### PR TITLE
Fixed scoped storage issue on Android 10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ allprojects {
 }
 
 ext {
-    compileSdkVersion = 28
-    buildToolsVersion = '28.0.3'
+    compileSdkVersion = 29
+    buildToolsVersion = '29.0.2'
     androidXLibraryVersion = '1.0.0'
 
     PUBLISH_GROUP_ID = 'com.theartofdev.edmodo'

--- a/cropper/src/main/AndroidManifest.xml
+++ b/cropper/src/main/AndroidManifest.xml
@@ -1,4 +1,16 @@
-<manifest
-    package="com.theartofdev.edmodo.cropper">
+<manifest package="com.theartofdev.edmodo.cropper"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths" />
+        </provider>
+    </application>
 
 </manifest>

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImage.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImage.java
@@ -189,13 +189,7 @@ public final class CropImage {
       allIntents.addAll(getCameraIntents(context, packageManager));
     }
 
-    List<Intent> galleryIntents =
-        getGalleryIntents(packageManager, Intent.ACTION_GET_CONTENT, includeDocuments);
-    if (galleryIntents.size() == 0) {
-      // if no intents found for get-content try pick intent action (Huawei P9).
-      galleryIntents = getGalleryIntents(packageManager, Intent.ACTION_PICK, includeDocuments);
-    }
-    allIntents.addAll(galleryIntents);
+    allIntents.add(getGalleryIntent(Intent.ACTION_GET_CONTENT, includeDocuments));
 
     Intent target;
     if (allIntents.isEmpty()) {
@@ -210,7 +204,7 @@ public final class CropImage {
 
     // Add all other intents
     chooserIntent.putExtra(
-        Intent.EXTRA_INITIAL_INTENTS, allIntents.toArray(new Parcelable[allIntents.size()]));
+            Intent.EXTRA_INITIAL_INTENTS, allIntents.toArray(new Parcelable[allIntents.size()]));
 
     return chooserIntent;
   }
@@ -262,35 +256,14 @@ public final class CropImage {
    * Get all Gallery intents for getting image from one of the apps of the device that handle
    * images.
    */
-  public static List<Intent> getGalleryIntents(
-      @NonNull PackageManager packageManager, String action, boolean includeDocuments) {
-    List<Intent> intents = new ArrayList<>();
-    Intent galleryIntent =
-        action == Intent.ACTION_GET_CONTENT
-            ? new Intent(action)
-            : new Intent(action, MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
-    galleryIntent.setType("image/*");
-    List<ResolveInfo> listGallery = packageManager.queryIntentActivities(galleryIntent, 0);
-    for (ResolveInfo res : listGallery) {
-      Intent intent = new Intent(galleryIntent);
-      intent.setComponent(new ComponentName(res.activityInfo.packageName, res.activityInfo.name));
-      intent.setPackage(res.activityInfo.packageName);
-      intents.add(intent);
-    }
+  public static Intent getGalleryIntent(String action, boolean includeDocuments) {
 
-    // remove documents intent
-    if (!includeDocuments) {
-      for (Intent intent : intents) {
-        if (intent
-            .getComponent()
-            .getClassName()
-            .equals("com.android.documentsui.DocumentsActivity")) {
-          intents.remove(intent);
-          break;
-        }
-      }
-    }
-    return intents;
+    Intent galleryIntent = new Intent();
+    galleryIntent.setAction(action);
+    galleryIntent.setType(includeDocuments ? "*/*" : "image/*");
+    galleryIntent.addCategory(Intent.CATEGORY_OPENABLE);
+
+    return galleryIntent;
   }
 
   /**
@@ -522,7 +495,7 @@ public final class CropImage {
      * @param fragment fragment to receive result
      */
     public void start(
-        @NonNull Context context, @NonNull Fragment fragment, @Nullable Class<?> cls) {
+            @NonNull Context context, @NonNull Fragment fragment, @Nullable Class<?> cls) {
       fragment.startActivityForResult(getIntent(context, cls), CROP_IMAGE_ACTIVITY_REQUEST_CODE);
     }
 

--- a/cropper/src/main/res/xml/provider_paths.xml
+++ b/cropper/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path
+        name="cache_files"
+        path="."/>
+</paths>


### PR DESCRIPTION
Fixed issue where the gallery options were not showing up in the image source picker on Android 10 devices. This is due to the new scoped storage requirements of 10. 
Limitations - unable to show gallery types on the picker. I could only manage to show a single file picker.
Test - run "quick start" on an Android 10 device. The gallery intents are not shown without this fix.